### PR TITLE
Log writer

### DIFF
--- a/library/Shanty/Log/Writer/Mongo.php
+++ b/library/Shanty/Log/Writer/Mongo.php
@@ -29,7 +29,7 @@ class Shanty_Log_Writer_Mongo extends Zend_Log_Writer_Abstract
     /**
      * Class constructor
      *
-     * @param string $documentClass         String representing your Mongo document class name§
+     * @param string $documentClass         String representing Mongo document class name
      * @param array $columnMap
      * @return void
      */

--- a/library/Shanty/Log/Writer/Mongo.php
+++ b/library/Shanty/Log/Writer/Mongo.php
@@ -1,0 +1,128 @@
+<?php
+
+/** Zend_Log_Writer_Abstract */
+require_once 'Zend/Log/Writer/Abstract.php';
+
+/**
+ * @category   Shanty
+ * @package    Shanty_Mongo
+ * @copyright  Shanty Tech Pty Ltd
+ * @license    New BSD License
+ * @author     Girish Nath
+ */
+class Shanty_Log_Writer_Mongo extends Zend_Log_Writer_Abstract
+{
+    /**
+     * Instance of Mongo document
+     *
+     * @var object Mongo document that extends Shanty_Mongo_Document
+     */
+    private $_documentClass;
+
+    /**
+     * Relates database columns names to log data field keys.
+     *
+     * @var null|array
+     */
+    private $_columnMap;
+
+    /**
+     * Class constructor
+     *
+     * @param string $documentClass         String representing your Mongo document class name§
+     * @param array $columnMap
+     * @return void
+     */
+    public function __construct($documentClass, $columnMap = null)
+    {
+        if (is_string ($documentClass)) {
+            $this->_documentClass = new $documentClass;
+        }
+        else {
+            require_once 'Zend/Log/Exception.php';
+            throw new Zend_Log_Exception('Document class name must be a string');
+        }
+        $this->_columnMap = $columnMap;
+    }
+
+    /**
+     * Create a new instance of Shanty_Log_Writer_Mongo
+     *
+     * @param  array|Zend_Config $config
+     * @return Shanty_Log_Writer_Mongo
+     */
+    static public function factory($config)
+    {
+        $config = self::_parseConfig($config);
+        $config = array_merge(array(
+            'documentClass' => null,
+            'columnMap' => null,
+        ), $config);
+        
+        if (isset($config['documentclass'])) {
+            $config['documentClass'] = $config['documentclass'];
+        }
+
+        if (isset($config['columnmap'])) {
+            $config['columnMap'] = $config['columnmap'];
+        }
+
+        return new self(
+            $config['documentClass'],
+            $config['columnMap']
+        );
+    }
+
+    /**
+     * Formatting is not possible on this writer
+     *
+     * @return void
+     * @throws Zend_Log_Exception
+     */
+    public function setFormatter(Zend_Log_Formatter_Interface $formatter)
+    {
+        require_once 'Zend/Log/Exception.php';
+        throw new Zend_Log_Exception(get_class($this) . ' does not support formatting');
+    }
+
+    /**
+     * Remove reference to the Mongo document 
+     *
+     * @return void
+     */
+    public function shutdown()
+    {
+        $this->_documentClass = null;
+    }
+
+    /**
+     * Write a message to the log.
+     *
+     * @param  array  $event  event data
+     * @return void
+     * @throws Zend_Log_Exception
+     */
+    protected function _write($event)
+    {
+        if ($this->_documentClass === null) {
+            require_once 'Zend/Log/Exception.php';
+            throw new Zend_Log_Exception('Document class is null');
+        }
+
+        if ($this->_columnMap === null) {
+            $dataToInsert = $event;
+        } else {
+            $dataToInsert = array();
+            foreach ($this->_columnMap as $columnName => $fieldKey) {
+                $dataToInsert[$columnName] = $event[$fieldKey];
+            }
+        }
+
+        // Populate the document and save
+        foreach ($dataToInsert as $key => $value) {
+            $this->_documentClass->$key = $value;
+        }
+        $this->_documentClass->save();
+        
+    }
+}


### PR DESCRIPTION
Hi

I've created a log writer for Shanty which is derived from Zend_Log_Writer_Db code (it also supports additional custom fields like Zend_Log_Writer_Db). Are you interested in pulling this into your repo?

https://github.com/GishX/Shanty-Mongo/tree/log-writer/library/Shanty/Log

Thanks. G
### Creating the log writer using Zend_Log::factory()

```
    $logger = Zend_Log::factory(array(
                'timestampFormat' => 'Y-m-d',
                array(
                    'writerName' => 'Mongo',
                    'writerNamespace' => 'Shanty_Log_Writer',
                    'writerParams' => array(
                        'documentClass' => 'My_Log_Document',
                        'columnMap' => array(
                            'priority' => 'priority',
                            'message' => 'message',
                            'timestamp' => 'timestamp',
                            'ip' => 'ip',
                            'username' => 'username'
                        )
                    ),
                )
            ));

    // Custom fields
    $logger->setEventItem('ip', $_SERVER['REMOTE_ADDR']);
    $logger->setEventItem('username', 'GishX');
    $logger->info('Log this message');  
```
### Create the log writer, then register it with Zend_Log()

```
    $writer = new Shanty_Log_Writer_Mongo(
                    'My_Log_Document',
                    array(
                        'priority' => 'priority',
                        'message' => 'message',
                        'timestamp' => 'timestamp',
                        'ip' => 'ip',
                        'username' => 'username'
                        )
            );

    // Create a logger and register the writer with it
    $logger = new Zend_Log($writer);

    // Custom fields
    $logger->setEventItem('ip', $_SERVER['REMOTE_ADDR']);
    $logger->setEventItem('username', 'GishX');            
    $logger->info('Log this message');
```
