### PR TITLE
Add composer.json for inclusion in packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "coen-hyde/shanty-mongo",
+    "description": "Shanty Mongo is a mongodb library for the Zend Framework.",
+    "keywords": ["zend", "mongodb", "orm", "nosql"],
+    "homepage": "https://github.com/coen-hyde/Shanty-Mongo",
+    "type": "library",
+    "license": "New BSD",
+    "authors": [
+        {
+            "name": "Coen Hyde",
+            "email": "coen.hyde@gmail.com",
+            "homepage": "http://coenhyde.com",
+        }
+    ],
+    "require": {
+        "php": ">=5.3"
+        // Zend Framework v1.x - not in Packagist
+    },
+    "autoload": {
+        "psr-0": { "Shanty": "library/" }
+    }
+}


### PR DESCRIPTION
I've added a composer.json file to include this project in http://packagist.org. You'll need to tweak whatever sections of the JSON you want and then submit it to http://packagist.org; the process is relatively straightforward.

Couple of notes:
- I'm not adding a version, so it'll refer to dev-master by default.
- I'm not including Zend Framework under "requires", since it isn't included in Packagist and I don't want to clobber anyone else's custom ZF packagist setups.
