### PR TITLE
use findandmodify in update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .settings
 tests/TestConfiguration.php
 library/Zend
+.DS_Store

--- a/library/Shanty/Mongo/Document.php
+++ b/library/Shanty/Mongo/Document.php
@@ -321,7 +321,11 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 		if ($writable) $connection = Shanty_Mongo::getWriteConnection($this->getConfigAttribute('connectionGroup'));
 		else $connection = Shanty_Mongo::getReadConnection($this->getConfigAttribute('connectionGroup'));
 		
-		return $connection->selectDB($this->getConfigAttribute('db'));
+		$temp = $connection->selectDB($this->getConfigAttribute('db'));
+		
+		$temp->w = 2;
+		
+		return $temp;
 	}
 	
 	/**
@@ -980,14 +984,37 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 			}
 		}
 		
-		$result = $this->_getMongoCollection(true)->update($this->getCriteria(), $operations, array('upsert' => true, 'safe' => $safe));
+		$result = false;
+		
+		if($this->isNewDocument())
+		{
+			$result = $this->_getMongoCollection(true)->update($this->getCriteria(), $operations, array('upsert' => true, 'safe' => $safe));
+			$this->_cleanData = $exportData;
+		}
+		else
+		{
+			$newversion = $this->_getMongoDb(true)->command(
+				array(
+						'findandmodify' => $this->getConfigAttribute('collection'), 
+						'query' => $this->getCriteria(), 
+						'update'=>$operations,
+						'new'=>true )
+						);
+
+			if(isset($newversion['value']))
+				$this->_cleanData = $newversion['value'];
+
+			if($newversion['ok'] == 1)
+				$result = true;
+		}
 		$this->_data = array();
-		$this->_cleanData = $exportData;
 		$this->purgeOperations(true);
 		
 		// Run post hooks
-		if ($this->isNewDocument()) $this->postInsert();
-		else $this->postUpdate();
+		if ($this->isNewDocument()) 
+			$this->postInsert();
+		else 
+			$this->postUpdate();
 		
 		$this->postSave();
 		


### PR DESCRIPTION
This change uses findandmodify with returned object, so that the object in shanty matches the DB after Save()

currently if you call operations like inc() etc the object they are performed on becomes out of sync with the database after you call save(), often in a replica set you can't even read back the same object after a save as it may not have propagated to the other servers in the set.
