### PR TITLE
Ignore properties

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -101,6 +101,9 @@ To use a filter add a requirement with the prefix 'Filter:' followed by the name
 - Required  
   Ensures that a property exists. Unlike most validators that run when a property is set, Required is run when a document is saved.
 
+- Ignore  
+  Will prevent a property/field being saved to Mongo. Allows overriding export() function and adding own computed data without persisting back to db.
+
 - AsReference  
   Will save a document as a reference
 

--- a/library/Shanty/Mongo/Document.php
+++ b/library/Shanty/Mongo/Document.php
@@ -852,7 +852,7 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 				throw new Shanty_Mongo_Exception("Property '{$property}' must not be null.");
 			}
 		}
-		
+				
 		return $exportData;
 	}
 	
@@ -935,6 +935,23 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 	}
 	
 	/**
+	 * Removes any properties that have been flagged as ignore in properties.
+	 *
+	 * @return array
+	 * @author Tom Holder
+	 **/
+	private function removeIgnoredProperties($exportData)
+	{
+		// remove ignored properties
+		$ignoreProperties = $this->getPropertiesWithRequirement('Ignore');
+		foreach ($ignoreProperties as $property) {
+			unset($exportData[$property]);
+		}
+		
+		return $exportData;
+	}
+	
+	/**
 	 * Save this document
 	 * 
 	 * @param boolean $entierDocument Force the saving of the entier document, instead of just the changes
@@ -959,7 +976,7 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 		
 		$this->preSave();
 		
-		$exportData = $this->export();
+		$exportData = $this->removeIgnoredProperties($this->export());
 		
 		if ($this->isRootDocument() && ($this->isNewDocument() || $entierDocument)) {
 			// Save the entier document

--- a/tests/Shanty/Mongo/DocumentTest.php
+++ b/tests/Shanty/Mongo/DocumentTest.php
@@ -1218,4 +1218,24 @@ class Shanty_Mongo_DocumentTest extends Shanty_Mongo_TestSetup
 	    $exportedData = $article->export();
 	    $this->assertEquals('102 reasons mongo is the bomb digidy', $exportedData['relatedArticles'][0]['title']);
 	}
+	
+	/**
+	 * Test for Ignore requirement.
+	 *
+	 * @return void
+	 * @author Tom Holder
+	 **/
+	public function testIgnoreRequirement()
+	{
+		
+		$doc = new My_ShantyMongo_SimpleWithExport();
+		$doc->field1 = 'Some Data';
+		$doc->save();
+		$id = $doc->getId();
+		
+		$savedDoc = My_ShantyMongo_SimpleWithExport::find($id);
+		
+		$this->assertNull($savedDoc->myIgnoredProperty);
+		$this->assertEquals('some data', $savedDoc->myUnignoredProperty);
+	}
 }

--- a/tests/Shanty/Mongo/_files/My/ShantyMongo/Simple.php
+++ b/tests/Shanty/Mongo/_files/My/ShantyMongo/Simple.php
@@ -7,4 +7,3 @@ class My_ShantyMongo_Simple extends My_ShantyMongo_Abstract
 	protected static $_db = TESTS_SHANTY_MONGO_DB;
 	protected static $_collection = 'simple';
 }
-?>

--- a/tests/Shanty/Mongo/_files/My/ShantyMongo/SimpleWithExport.php
+++ b/tests/Shanty/Mongo/_files/My/ShantyMongo/SimpleWithExport.php
@@ -1,0 +1,20 @@
+<?php
+
+require_once 'My/ShantyMongo/Abstract.php';
+
+class My_ShantyMongo_SimpleWithExport extends My_ShantyMongo_Abstract
+{
+	protected static $_requirements = array(
+		'myIgnoredProperty' => 'Ignore'
+	);
+	
+	protected static $_db = TESTS_SHANTY_MONGO_DB;
+	protected static $_collection = 'simple';
+	
+	public function export() {
+		$data = parent::export();
+		$data['myIgnoredProperty'] = 'some data';
+		$data['myUnignoredProperty'] = 'some data';
+		return $data;
+	}
+}

--- a/tests/Shanty/TestSetup.php
+++ b/tests/Shanty/TestSetup.php
@@ -48,6 +48,7 @@ class Shanty_TestSetup extends PHPUnit_Framework_TestCase
 		require_once 'My/ShantyMongo/Article.php';
 		require_once 'My/ShantyMongo/InvalidDocument.php';
 		require_once 'My/ShantyMongo/Simple.php';
+		require_once 'My/ShantyMongo/SimpleWithExport.php';
 
 		$this->_connection = new Shanty_Mongo_Connection(TESTS_SHANTY_MONGO_CONNECTIONSTRING);
 		$this->_connection->connect();


### PR DESCRIPTION
@coen-hyde could you have a look at this? I've had a few instanced where I've need to override export to add custom data but don't want it persisted back to mongo.

This adds a simple 'Ignore' requirement to prevent a field being saved to Mongo.
