### PR TITLE
Custom requirements

### DIFF
--- a/library/Shanty/Mongo.php
+++ b/library/Shanty/Mongo.php
@@ -60,8 +60,13 @@ class Shanty_Mongo
 		
 		// Requirement creator for filters
 		static::storeRequirementCreator('/^Filter:([A-Za-z]+[\w\-:]*)$/', function($data, $options = null) {
-			$instanceClass = 'Zend_Filter_'.$data[1];
-			if (!class_exists($instanceClass)) return null;
+			$instanceClass = $data[1];
+			if (!class_exists($instanceClass)) {
+				$instanceClass = 'Zend_Filter_'.$instanceClass;
+				if (!class_exists($instanceClass)) {
+					return null;
+				}
+			}
 			
 			if (!is_null($options)) $validator = new $instanceClass($options);
 			else $validator = new $instanceClass();

--- a/tests/Shanty/MongoTest.php
+++ b/tests/Shanty/MongoTest.php
@@ -269,6 +269,13 @@ class Shanty_MongoTest extends Shanty_Mongo_TestSetup
 		$this->assertEquals('Zend_Validate_EmailAddress', get_class($requirement));
 	}
 
+	public function testCustomFilter()
+	{
+		$requirement = Shanty_Mongo::createRequirement('Filter:Zend_Filter_Alpha');
+		$this->assertInternalType(PHPUnit_Framework_Constraint_IsType::TYPE_OBJECT, $requirement);
+		$this->assertEquals('Zend_Filter_Alpha', get_class($requirement));
+	}
+
 	public static function validOperations()
 	{
 		return array(


### PR DESCRIPTION
I wanted to run a custom `Zend_Filter_Interface` class against a field, but looking at the source code it seems that Shanty is special cased to look for `Zend_Filter_` as a prefix.

I know you can register a custom validator with Shanty using `storeRequirement`…

``` php
Shanty_Mongo::storeRequirement('PigLatin', new My_Filter_PigLatin())
```

…but as @tholder mentioned in #36, this makes it harder to track which code is using which filter/validator a given model is using.

This change first checks if a filter or validator is an existing class, then it adds the prefix if the class isn't found. Allowing models to declare filters and validators that are class names.

``` php
class User extends Shanty_Mongo_Document
{
    protected static $_requirements = array(
        'bio' => array('Filter:My_Filter_PigLatin')
    );
}
```
