### PR TITLE
Add Ignore requirement

### DIFF
--- a/library/Shanty/Mongo.php
+++ b/library/Shanty/Mongo.php
@@ -38,6 +38,7 @@ class Shanty_Mongo
 		// Stubs
 		static::storeRequirement('Required', new Shanty_Mongo_Validate_StubTrue());
 		static::storeRequirement('AsReference', new Shanty_Mongo_Validate_StubTrue());
+		static::storeRequirement('Ignore', new Shanty_Mongo_Validate_StubTrue());
 		
 		// Requirement creator for validators
 		static::storeRequirementCreator('/^Validator:([A-Za-z]+[\w\-:]*)$/', function($data, $options = null) {

--- a/tests/Shanty/Mongo/DocumentTest.php
+++ b/tests/Shanty/Mongo/DocumentTest.php
@@ -1241,6 +1241,9 @@ class Shanty_Mongo_DocumentTest extends Shanty_Mongo_TestSetup
 		$savedDoc->field2 = 'more data';
 		$savedDoc->save();
 		
+		// Test setting an ignored property
+		$savedDoc->myIgnoredProperty = "foo";
+
 		$savedAgainDoc = My_ShantyMongo_SimpleWithExport::find($id);
 		$this->assertNull($savedAgainDoc->myIgnoredProperty);
 		$this->assertEquals('some data', $savedAgainDoc->myUnignoredProperty);


### PR DESCRIPTION
When trying to set a property marked as `Ignore`, I was getting an exception:

```
Shanty_Mongo_Exception: No requirement exists for 'Ignore'
```

I've added a test for the failing behaviour and added the requirement definition.
