### PR TITLE
Replaces old Master / Slave stuff with a simple connection setup

### DIFF
--- a/library/Shanty/Mongo/Collection.php
+++ b/library/Shanty/Mongo/Collection.php
@@ -250,8 +250,7 @@ abstract class Shanty_Mongo_Collection
 	 */
 	public static function getConnection($writable = true)
 	{
-		if ($writable) $connection = Shanty_Mongo::getWriteConnection(static::getConnectionGroupName());
-		else $connection = Shanty_Mongo::getReadConnection(static::getConnectionGroupName());
+		$connection = Shanty_Mongo::getConnectionForGroup(static::getConnectionGroupName());
 
 		return $connection;
 	}

--- a/library/Shanty/Mongo/Connection.php
+++ b/library/Shanty/Mongo/Connection.php
@@ -27,7 +27,7 @@ class Shanty_Mongo_Connection extends Mongo
 		if (is_null($connectionString)) $connectionString = '127.0.0.1';
 
 		// Force mongo to connect only when we need to
-		$options['connect'] = false;
+		//$options['connect'] = false;
 		$connectionInfo = self::parseConnectionString($connectionString);
 		
 		$this->_connectionInfo = array_merge($options, $connectionInfo);
@@ -63,7 +63,8 @@ class Shanty_Mongo_Connection extends Mongo
 	 */
 	public function getDatabase()
 	{
-		if (!isset($this->_connectionInfo['database'])) return null;
+		if (!isset($this->_connectionInfo['database'])) 
+			return null;
 
 		return $this->_connectionInfo['database'];
 	}

--- a/library/Shanty/Mongo/Document.php
+++ b/library/Shanty/Mongo/Document.php
@@ -318,13 +318,9 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 			throw new Shanty_Mongo_Exception('Can not fetch instance of MongoDb. Document is not connected to a db.');
 		}
 		
-		if ($writable) $connection = Shanty_Mongo::getWriteConnection($this->getConfigAttribute('connectionGroup'));
-		else $connection = Shanty_Mongo::getReadConnection($this->getConfigAttribute('connectionGroup'));
+		$connection = Shanty_Mongo::getConnectionForGroup($this->getConfigAttribute('connectionGroup'));
 		
 		$temp = $connection->selectDB($this->getConfigAttribute('db'));
-		
-		$temp->w = 2;
-		
 		return $temp;
 	}
 	


### PR DESCRIPTION
You can now setup connections to replica sets like:

```

    $connection = new Shanty_Mongo_Connection("mongodb://user:password@db.yourserver.com:27017");

    $connection->setSlaveOkay(true);    // optional to offload reads to slaves

    Shanty_Mongo::addConnection($connection);
```

as per the php-mongo docs your connection string can look like
"mongodb://db1.example.net,db2.example.net:2500/?replicaSet=test" or you can pass the replica set in as an array in a second param!

addConnection optionally takes a connection group just like the old stuff! 

This fixes the problem with replica set connections I saw previously.
