### PR TITLE
new Mongo extension + namespaces in Documents

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4",
+        "ext-mongo" : ">=1.4.0",
     },
     "require-dev": {
         "digital-canvas/zend-framework": "1.12.0",

--- a/library/Shanty/Mongo.php
+++ b/library/Shanty/Mongo.php
@@ -41,7 +41,7 @@ class Shanty_Mongo
 		static::storeRequirement('Ignore', new Shanty_Mongo_Validate_StubTrue());
 		
 		// Requirement creator for validators
-		static::storeRequirementCreator('/^Validator:([A-Za-z]+[\w\-:]*)$/', function($data, $options = null) {
+        static::storeRequirementCreator('/^Validator:([A-Za-z\\\]+[\w\-:]*)$/', function($data, $options = null) {
 			$instanceClass = $data[1];
 			if (!class_exists($instanceClass)) {
 				$instanceClass = 'Zend_Validate_'.$instanceClass;
@@ -60,7 +60,7 @@ class Shanty_Mongo
 		});
 		
 		// Requirement creator for filters
-		static::storeRequirementCreator('/^Filter:([A-Za-z]+[\w\-:]*)$/', function($data, $options = null) {
+        static::storeRequirementCreator('/^Filter:([A-Za-z\\\]+[\w\-:]*)$/', function($data, $options = null) {
 			$instanceClass = $data[1];
 			if (!class_exists($instanceClass)) {
 				$instanceClass = 'Zend_Filter_'.$instanceClass;
@@ -83,9 +83,9 @@ class Shanty_Mongo
 			
 			return new Shanty_Mongo_Validate_Class($data[1]);
 		};
-		
-		static::storeRequirementCreator('/^Document:([A-Za-z]+[\w\-]*)$/', $classValidator);
-		static::storeRequirementCreator('/^DocumentSet:([A-Za-z]+[\w\-]*)$/', $classValidator);
+
+        static::storeRequirementCreator('/^Document:([A-Za-z\\\]+[\w\-]*)$/', $classValidator);
+        static::storeRequirementCreator('/^DocumentSet:([A-Za-z\\\]+[\w\-]*)$/', $classValidator);
 		
 		static::$_initialised = true;
 	}

--- a/library/Shanty/Mongo/Connection.php
+++ b/library/Shanty/Mongo/Connection.php
@@ -13,7 +13,7 @@ class Shanty_Mongo_Connection extends Mongo
 {
 	static protected $_availableOptions = array(
 		'persist',
-		'timeout',
+		'connectTimeoutMS',
 		'replicaSet'
 	);
 	

--- a/library/Shanty/Mongo/Connection/Group.php
+++ b/library/Shanty/Mongo/Connection/Group.php
@@ -180,7 +180,11 @@ class Shanty_Mongo_Connection_Group
 		$connectionString .= implode(',', $hostStringList);
 
 		// Set database
-		if (isset($connectionOptions['database'])) $connectionString .= '/'.$connectionOptions['database'];
+		if (isset($connectionOptions['database'])) {
+            $connectionString .= '/'.$connectionOptions['database'];
+        } elseif (isset($connectionOptions['path'])) {
+            $connectionString .= $connectionOptions['path'];
+        }
 
 		return $connectionString;
 	}

--- a/library/Shanty/Mongo/Connection/Group.php
+++ b/library/Shanty/Mongo/Connection/Group.php
@@ -130,7 +130,8 @@ class Shanty_Mongo_Connection_Group
 	{
 		// Select master
 		$write = $this->_masters->selectNode();
-		if ($write && !$write->connected) {
+        $connections = $write->getConnections();
+		if ($write && empty($connections)) {
                     $write->connect();
                 }
 		

--- a/library/Shanty/Mongo/Document.php
+++ b/library/Shanty/Mongo/Document.php
@@ -951,7 +951,8 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 		
 		foreach ($this->_data as $property => $document) {
 			if (!($document instanceof Shanty_Mongo_Document)) continue;
-			
+			if ($this->isReference($document) || $this->hasRequirement($property, 'AsReference')) continue;
+
 			$document->removeIgnoredProperties($exportData[$property]);
 		}
 			

--- a/library/Shanty/Mongo/Document.php
+++ b/library/Shanty/Mongo/Document.php
@@ -395,8 +395,8 @@ class Shanty_Mongo_Document extends Shanty_Mongo_Collection implements ArrayAcce
 					
 					// Find the document class
 					$matches = array();
-					preg_match("/^{$requirement}:([A-Za-z][\w\-]*)$/", $requirementSearch, $matches);
-					
+                    preg_match("/^{$requirement}:([A-Za-z\\\\][\\w\\\\]*)/", $requirementSearch, $matches);
+
 					if (!empty($matches)) {
 						if (!class_exists($matches[1])) {
 							require_once 'Shanty/Mongo/Exception.php';


### PR DESCRIPTION
```
The library is working with the latest Mongo Extension for php. All deprecated attributes and options were fixed.
The Documents can contain Namespace paths in their declaration.
```
